### PR TITLE
Move disposal check in BaseViewModel from setState to notifyListeners

### DIFF
--- a/lib/core/view_models/base_view_model.dart
+++ b/lib/core/view_models/base_view_model.dart
@@ -12,10 +12,13 @@ class BaseViewModel extends ChangeNotifier {
 
   void setState(ViewState viewState) {
     _state = viewState;
-
-    if (_disposed) return;
-
     notifyListeners();
+  }
+
+  @override
+  void notifyListeners() {
+    if (_disposed) return;
+    super.notifyListeners();
   }
 
   @override


### PR DESCRIPTION
Fixes a model disposal issue if using notifyListeners instead of setState.